### PR TITLE
Fix compilation errors: windows visual studio 2019

### DIFF
--- a/tinydream.hpp
+++ b/tinydream.hpp
@@ -81,7 +81,11 @@ private:
     std::string imgPrefix{ "tinydream_" };
     std::function<void(const char* /* zLogMsg */, int /* msg length */ , void* /* pCookie */)> xLog{nullptr};
     void* xLogUserData{ nullptr };
-    inline constexpr void _log(const std::string& msg) const {
+#if (defined(_MSC_VER) && _MSC_VER <= 1929) // not sure exactly what version supports this - 1929 doesn't
+    inline void _log(const std::string& msg) const {
+#else 
+    inline constexpr void _log(const std::string & msg) const {
+#endif
         if (xLog) {
             xLog(msg.c_str(), static_cast<int>(msg.size()), xLogUserData);
         }
@@ -425,7 +429,7 @@ std::vector<std::pair<std::string, float>> tinyDream::parsePromptAttention(std::
 
             round_brackets.pop();
         }
-        else if (text == "]" and square_brackets.size() > 0)
+        else if (text == "]" && square_brackets.size() > 0)
         {
             for (unsigned long p = square_brackets.top(); p < res.size(); p++)
             {
@@ -615,7 +619,7 @@ bool tinyDream::loadTokens()
         _log("[-Info-]: Token Embedding  - Tokens Table Already Loaded. Skipping\n");
     return true;
 }
-bool tinyDream::dream(const std::string& positivePrompt, const std::string& negativePrompt, std::string& outputImgPath, bool upScale = true, int seed = 42, int step = 30)
+bool tinyDream::dream(const std::string& positivePrompt, const std::string& negativePrompt, std::string& outputImgPath, bool upScale, int seed, int step)
 {
     if (positivePrompt.empty()) {
         _log(std::string{ "[-ERROR-]: Missing Positive Prompt (Keywords): Describe something you'd like to see generated using words separated by commas. High priority or meta instructions must be surrounded by parenthesis.\n" });


### PR DESCRIPTION
Fixes for compiling with `_MSC_VER = 1929` and precompiled ncnn lib [ncnn-20230816-windows-vs2019](https://github.com/Tencent/ncnn/releases/download/20230816/ncnn-20230816-windows-vs2019.zip) :
Fixes these errors:
* compiler tells `_log` can't be constexpr
* doesn't support `and` keyword
* default arguments defined twice, both on declaration and implementation

Otherwise had to also hack cmake file etc. But part of that is my machine specific, so didn't include it.
In case anyone finds it useful, my cmake file:
```CMake
cmake_minimum_required(VERSION 3.7)
project(PIXLAB_TINY_DREAM)
set(CMAKE_BUILD_TYPE Release)
set(CMAKE_CXX_STANDARD 17)
#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -funsafe-math-optimizations -Ofast -flto=auto  -funroll-all-loops -pipe -march=native -Wall ")

#MY MACHINE SPECIFIC
list(APPEND CMAKE_PREFIX_PATH "${CMAKE_CURRENT_SOURCE_DIR}/deps/ncnn-20230816-windows-vs2019/x64/lib/cmake/ncnn")
set(NCNN_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/deps/ncnn-20230816-windows-vs2019/x64/")
find_package(Vulkan REQUIRED)
include_directories(${Vulkan_INCLUDE_DIR})
#find_package(OpenMP REQUIRED)

find_package(ncnn REQUIRED)
if (ncnn_FOUND)
	message("NCNN inference engine available")
	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${ncnn_C_FLAGS}")
	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${ncnn_CXX_FLAGS}")
	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${ncnn_EXE_LINKER_FLAGS}")
    message(STATUS "ncnn_LIBS: ${ncnn_LIBS}")
    message(STATUS "ncnn_INCLUDE_DIRS: ${ncnn_INCLUDE_DIRS}")
else ()
    message(FATAL_ERROR "NCNN inference engine not found. Please install the library first!")
endif ()
include_directories("${NCNN_ROOT}/include")

include_directories(${CMAKE_CURRENT_SOURCE_DIR})
include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
link_directories(${NCNN_ROOT}/lib)

set(EXECUTABLE_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/)
add_executable(PIXLAB_TINY_DREAM "boilerplate.cpp" "tinydream.hpp")
if (!WIN32)
	target_link_libraries(${PROJECT_NAME} ncnn pthread)
else()
	target_compile_definitions(${PROJECT_NAME} PUBLIC NOMINMAX)
endif()
set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME "tinydream")
target_link_libraries(${PROJECT_NAME} Vulkan::Vulkan)
target_link_libraries(${PROJECT_NAME} ncnn)
```
Compiled with `cmake --build . --target ALL_BUILD --config Release `
